### PR TITLE
CC-7836: Adjust `ProductLabelStorageClient::findLabelByName` client method

### DIFF
--- a/src/Spryker/Client/ProductLabelStorage/ProductLabelStorageClient.php
+++ b/src/Spryker/Client/ProductLabelStorage/ProductLabelStorageClient.php
@@ -74,14 +74,15 @@ class ProductLabelStorageClient extends AbstractClient implements ProductLabelSt
      *
      * @param string $labelName
      * @param string $localeName
+     * @param string|null $storeName
      *
      * @return \Generated\Shared\Transfer\ProductLabelDictionaryItemTransfer|null
      */
-    public function findLabelByName($labelName, $localeName)
+    public function findLabelByName($labelName, $localeName, ?string $storeName = null)
     {
         return $this
             ->getFactory()
             ->createLabelDictionaryReader()
-            ->findLabelByName($labelName, $localeName);
+            ->findLabelByName($labelName, $localeName, $storeName);
     }
 }

--- a/src/Spryker/Client/ProductLabelStorage/ProductLabelStorageClientInterface.php
+++ b/src/Spryker/Client/ProductLabelStorage/ProductLabelStorageClientInterface.php
@@ -51,14 +51,16 @@ interface ProductLabelStorageClientInterface
 
     /**
      * Specification:
-     * - TODO: add specification
+     * - Retrieves label for given label name, locale and store name.
+     * - Forward compatibility (from the next major): only label assigned with passed $storeName will be returned.
      *
      * @api
      *
      * @param string $labelName
      * @param string $localeName
+     * @param string|null $storeName
      *
      * @return \Generated\Shared\Transfer\ProductLabelDictionaryItemTransfer|null
      */
-    public function findLabelByName($labelName, $localeName);
+    public function findLabelByName($labelName, $localeName, ?string $storeName = null);
 }

--- a/src/Spryker/Client/ProductLabelStorage/ProductLabelStorageClientInterface.php
+++ b/src/Spryker/Client/ProductLabelStorage/ProductLabelStorageClientInterface.php
@@ -52,7 +52,7 @@ interface ProductLabelStorageClientInterface
     /**
      * Specification:
      * - Retrieves label for given label name, locale and store name.
-     * - Forward compatibility (from the next major): only label assigned with passed $storeName will be returned.
+     * - Forward compatibility: only label assigned with passed $storeName will be returned.
      *
      * @api
      *

--- a/src/Spryker/Client/ProductLabelStorage/Storage/Dictionary/LabelDictionary.php
+++ b/src/Spryker/Client/ProductLabelStorage/Storage/Dictionary/LabelDictionary.php
@@ -130,7 +130,7 @@ class LabelDictionary implements LabelDictionaryInterface
      *
      * @return array|null
      */
-    protected function getStorageData($localeName, ?string $storeName = null)
+    protected function getStorageData(string $localeName, ?string $storeName = null)
     {
         if (ProductLabelStorageConfig::isCollectorCompatibilityMode()) {
             $productLabelConstantsClassName = '\Spryker\Shared\ProductLabel\ProductLabelConstants';

--- a/src/Spryker/Client/ProductLabelStorage/Storage/Dictionary/LabelDictionary.php
+++ b/src/Spryker/Client/ProductLabelStorage/Storage/Dictionary/LabelDictionary.php
@@ -50,12 +50,13 @@ class LabelDictionary implements LabelDictionaryInterface
     /**
      * @param string $dictionaryKey
      * @param string $localeName
+     * @param string|null $storeName
      *
      * @return \Generated\Shared\Transfer\ProductLabelDictionaryItemTransfer|null
      */
-    public function findLabel($dictionaryKey, $localeName)
+    public function findLabel($dictionaryKey, $localeName, ?string $storeName = null)
     {
-        $dictionary = $this->getDictionary($localeName);
+        $dictionary = $this->getDictionary($localeName, $storeName);
 
         if (!array_key_exists($dictionaryKey, $dictionary)) {
             return null;
@@ -66,17 +67,18 @@ class LabelDictionary implements LabelDictionaryInterface
 
     /**
      * @param string $localeName
+     * @param string|null $storeName
      *
      * @return \Generated\Shared\Transfer\ProductLabelDictionaryItemTransfer[]
      */
-    public function getDictionary($localeName)
+    public function getDictionary($localeName, ?string $storeName = null)
     {
         static $labelDictionary = [];
 
         $strategy = get_class($this->dictionaryKeyStrategy);
 
         if (!isset($labelDictionary[$strategy])) {
-            $labelDictionary[$strategy] = $this->initializeLabelDictionary($localeName);
+            $labelDictionary[$strategy] = $this->initializeLabelDictionary($localeName, $storeName);
         }
 
         return $labelDictionary[$strategy];
@@ -84,14 +86,15 @@ class LabelDictionary implements LabelDictionaryInterface
 
     /**
      * @param string $localeName
+     * @param string|null $storeName
      *
      * @return \Generated\Shared\Transfer\ProductLabelDictionaryItemTransfer[]
      */
-    protected function initializeLabelDictionary($localeName)
+    protected function initializeLabelDictionary($localeName, ?string $storeName = null)
     {
         $labelDictionary = [];
 
-        $productLabelDictionaryStorageTransfer = $this->readLabelDictionary($localeName);
+        $productLabelDictionaryStorageTransfer = $this->readLabelDictionary($localeName, $storeName);
         foreach ($productLabelDictionaryStorageTransfer->getItems() as $productLabelDictionaryItemTransfer) {
             $dictionaryKey = $this->dictionaryKeyStrategy->getDictionaryKey($productLabelDictionaryItemTransfer);
             $labelDictionary[$dictionaryKey] = $productLabelDictionaryItemTransfer;
@@ -102,14 +105,15 @@ class LabelDictionary implements LabelDictionaryInterface
 
     /**
      * @param string $localeName
+     * @param string|null $storeName
      *
      * @return \Generated\Shared\Transfer\ProductLabelDictionaryStorageTransfer
      */
-    protected function readLabelDictionary($localeName)
+    protected function readLabelDictionary($localeName, ?string $storeName = null)
     {
         $productLabelDictionaryStorageTransfer = new ProductLabelDictionaryStorageTransfer();
 
-        $productLabelDictionaryStorageData = $this->getStorageData($localeName);
+        $productLabelDictionaryStorageData = $this->getStorageData($localeName, $storeName);
 
         if (!$productLabelDictionaryStorageData) {
             return $productLabelDictionaryStorageTransfer;
@@ -122,10 +126,11 @@ class LabelDictionary implements LabelDictionaryInterface
 
     /**
      * @param string $localeName
+     * @param string|null $storeName
      *
      * @return array|null
      */
-    protected function getStorageData(string $localeName)
+    protected function getStorageData($localeName, ?string $storeName = null)
     {
         if (ProductLabelStorageConfig::isCollectorCompatibilityMode()) {
             $productLabelConstantsClassName = '\Spryker\Shared\ProductLabel\ProductLabelConstants';
@@ -143,7 +148,7 @@ class LabelDictionary implements LabelDictionaryInterface
             return $formatted;
         }
 
-        $storageKey = $this->getStorageKey($localeName);
+        $storageKey = $this->getStorageKey($localeName, $storeName);
         $productLabelDictionaryStorageData = $this->storageClient->get($storageKey);
 
         return $productLabelDictionaryStorageData;
@@ -151,10 +156,11 @@ class LabelDictionary implements LabelDictionaryInterface
 
     /**
      * @param string $localeName
+     * @param string|null $storeName
      *
      * @return string
      */
-    protected function getStorageKey($localeName)
+    protected function getStorageKey($localeName, ?string $storeName = null)
     {
         $synchronizationDataTransfer = new SynchronizationDataTransfer();
         $synchronizationDataTransfer

--- a/src/Spryker/Client/ProductLabelStorage/Storage/Dictionary/LabelDictionaryInterface.php
+++ b/src/Spryker/Client/ProductLabelStorage/Storage/Dictionary/LabelDictionaryInterface.php
@@ -12,15 +12,17 @@ interface LabelDictionaryInterface
     /**
      * @param string $dictionaryKey
      * @param string $localeName
+     * @param string|null $storeName
      *
      * @return \Generated\Shared\Transfer\ProductLabelDictionaryItemTransfer|null
      */
-    public function findLabel($dictionaryKey, $localeName);
+    public function findLabel($dictionaryKey, $localeName, ?string $storeName = null);
 
     /**
      * @param string $localeName
+     * @param string|null $storeName
      *
      * @return \Generated\Shared\Transfer\ProductLabelDictionaryItemTransfer[]
      */
-    public function getDictionary($localeName);
+    public function getDictionary($localeName, ?string $storeName = null);
 }

--- a/src/Spryker/Client/ProductLabelStorage/Storage/LabelDictionaryReader.php
+++ b/src/Spryker/Client/ProductLabelStorage/Storage/LabelDictionaryReader.php
@@ -69,14 +69,22 @@ class LabelDictionaryReader implements LabelDictionaryReaderInterface
     /**
      * @param string $labelName
      * @param string $localeName
+     * @param string|null $storeName
      *
      * @return \Generated\Shared\Transfer\ProductLabelDictionaryItemTransfer|null
      */
-    public function findLabelByName($labelName, $localeName)
+    public function findLabelByName($labelName, $localeName, ?string $storeName = null)
     {
+        if (!$storeName) {
+            trigger_error(
+                'Pass the $storeName parameter for the forward compatibility with next major version.',
+                E_USER_DEPRECATED
+            );
+        }
+
         return $this->dictionaryFactory
             ->createDictionaryByName()
-            ->findLabel($labelName, $localeName);
+            ->findLabel($labelName, $localeName, $storeName);
     }
 
     /**

--- a/src/Spryker/Client/ProductLabelStorage/Storage/LabelDictionaryReaderInterface.php
+++ b/src/Spryker/Client/ProductLabelStorage/Storage/LabelDictionaryReaderInterface.php
@@ -36,8 +36,9 @@ interface LabelDictionaryReaderInterface
     /**
      * @param string $labelName
      * @param string $localeName
+     * @param string|null $storeName
      *
      * @return \Generated\Shared\Transfer\ProductLabelDictionaryItemTransfer|null
      */
-    public function findLabelByName($labelName, $localeName);
+    public function findLabelByName($labelName, $localeName, ?string $storeName = null);
 }


### PR DESCRIPTION
Branch: backport/cc-7836/product-label-storage-1.6.0
Ticket: https://spryker.atlassian.net/browse/CC-8456
Epic Ticket: https://spryker.atlassian.net/browse/CC-7836

Target Version: 1.6.0

https://release.spryker.com/release/hotfix?pr=https%3A%2F%2Fgithub.com%2Fspryker%2Fproduct-label-storage%2Fpull%2F1

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   ProductLabelStorage               | minor                 |                       |

#### Release Notes

{skip}

-----------------------------------------

#### Module ProductLabelStorage

##### Change log

Improvements

- Adjusted client method `ProductLabelStorageClient::findLabelByName()` with optional store name parameter to get store specific label.
