### PR TITLE
AA-36 added backport Client functions findOne and get

### DIFF
--- a/src/Spryker/Client/ProductLabelStorage/ProductLabelStorageClient.php
+++ b/src/Spryker/Client/ProductLabelStorage/ProductLabelStorageClient.php
@@ -7,6 +7,9 @@
 
 namespace Spryker\Client\ProductLabelStorage;
 
+use Generated\Shared\Transfer\ProductLabelStorageCollectionTransfer;
+use Generated\Shared\Transfer\ProductLabelStorageCriteriaTransfer;
+use Generated\Shared\Transfer\ProductLabelStorageTransfer;
 use Generated\Shared\Transfer\ProductViewTransfer;
 use Spryker\Client\Kernel\AbstractClient;
 
@@ -147,5 +150,33 @@ class ProductLabelStorageClient extends AbstractClient implements ProductLabelSt
         return $this->getFactory()
             ->createProductViewExpander()
             ->expand($productViewTransfer, $locale);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @api
+     *
+     * @param \Generated\Shared\Transfer\ProductLabelStorageCriteriaTransfer $productLabelStorageCriteriaTransfer
+     *
+     * @return \Generated\Shared\Transfer\ProductLabelStorageTransfer|null
+     */
+    public function findOne(ProductLabelStorageCriteriaTransfer $productLabelStorageCriteriaTransfer): ?ProductLabelStorageTransfer
+    {
+        return $this->getFactory()->createProductLabelReader()->findProductLabel($productLabelStorageCriteriaTransfer);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @api
+     *
+     * @param \Generated\Shared\Transfer\ProductLabelStorageCriteriaTransfer $productLabelStorageCriteriaTransfer
+     *
+     * @return \Generated\Shared\Transfer\ProductLabelStorageCollectionTransfer
+     */
+    public function get(ProductLabelStorageCriteriaTransfer $productLabelStorageCriteriaTransfer): ProductLabelStorageCollectionTransfer
+    {
+        return $this->getFactory()->createProductLabelReader()->getProductLabelCollection($productLabelStorageCriteriaTransfer);
     }
 }

--- a/src/Spryker/Client/ProductLabelStorage/ProductLabelStorageClientInterface.php
+++ b/src/Spryker/Client/ProductLabelStorage/ProductLabelStorageClientInterface.php
@@ -7,6 +7,9 @@
 
 namespace Spryker\Client\ProductLabelStorage;
 
+use Generated\Shared\Transfer\ProductLabelStorageCollectionTransfer;
+use Generated\Shared\Transfer\ProductLabelStorageCriteriaTransfer;
+use Generated\Shared\Transfer\ProductLabelStorageTransfer;
 use Generated\Shared\Transfer\ProductViewTransfer;
 
 interface ProductLabelStorageClientInterface
@@ -95,4 +98,38 @@ interface ProductLabelStorageClientInterface
         string $locale,
         ?string $storeName = null
     ): ProductViewTransfer;
+
+    /**
+     * Specification:
+     * - Returns null if no productLabelIds or storeName or localeName in ProductLabelStorageCriteriaTransfer exist
+     * - Retrieves ProductLabels from storage and returns correct ProductLabelStorage
+     * - Filters by:
+     *
+     * - Returns null if requested ProductLabel is not found
+     *
+     * @api
+     *
+     * @param \Generated\Shared\Transfer\ProductLabelStorageCriteriaTransfer $productLabelStorageCriteriaTransfer
+     *
+     * @return \Generated\Shared\Transfer\ProductLabelStorageTransfer|null
+     */
+    public function findOne(ProductLabelStorageCriteriaTransfer $productLabelStorageCriteriaTransfer): ?ProductLabelStorageTransfer;
+
+    /**
+     * Specification:
+     * - Returns ProductLabelStorageCollectionTransfer based on given ProductLabelStorageCriteriaTransfer
+     * - Filters by:
+     *      - localeName
+     *      - storeName
+     *      - productLabelIds
+     *      - productAbstractIds
+     *      - productLabelNames
+     *
+     * @api
+     *
+     * @param \Generated\Shared\Transfer\ProductLabelStorageCriteriaTransfer $productLabelStorageCriteriaTransfer
+     *
+     * @return \Generated\Shared\Transfer\ProductLabelStorageCollectionTransfer
+     */
+    public function get(ProductLabelStorageCriteriaTransfer $productLabelStorageCriteriaTransfer): ProductLabelStorageCollectionTransfer;
 }

--- a/src/Spryker/Client/ProductLabelStorage/ProductLabelStorageFactory.php
+++ b/src/Spryker/Client/ProductLabelStorage/ProductLabelStorageFactory.php
@@ -11,6 +11,8 @@ use Spryker\Client\Kernel\AbstractFactory;
 use Spryker\Client\ProductLabelStorage\Dependency\Service\ProductLabelStorageToUtilEncodingServiceInterface;
 use Spryker\Client\ProductLabelStorage\ProductView\ProductViewExpander;
 use Spryker\Client\ProductLabelStorage\ProductView\ProductViewExpanderInterface;
+use Spryker\Client\ProductLabelStorage\Reader\ProductLabelStorageReader;
+use Spryker\Client\ProductLabelStorage\Reader\ProductLabelStorageReaderInterface;
 use Spryker\Client\ProductLabelStorage\Storage\Dictionary\DictionaryFactory;
 use Spryker\Client\ProductLabelStorage\Storage\LabelDictionaryReader;
 use Spryker\Client\ProductLabelStorage\Storage\ProductAbstractLabelReader;
@@ -84,5 +86,16 @@ class ProductLabelStorageFactory extends AbstractFactory
     public function getStore()
     {
         return $this->getProvidedDependency(ProductLabelStorageDependencyProvider::STORE);
+    }
+
+    /**
+     * @return \Spryker\Client\ProductLabelStorage\Reader\ProductLabelStorageReaderInterface
+     */
+    public function createProductLabelReader(): ProductLabelStorageReaderInterface
+    {
+        return new ProductLabelStorageReader(
+            $this->createDictionaryFactory(),
+            $this->createProductAbstractLabelStorageReader()
+        );
     }
 }

--- a/src/Spryker/Client/ProductLabelStorage/Reader/ProductLabelStorageReader.php
+++ b/src/Spryker/Client/ProductLabelStorage/Reader/ProductLabelStorageReader.php
@@ -1,0 +1,112 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace Spryker\Client\ProductLabelStorage\Reader;
+
+use Generated\Shared\Transfer\ProductLabelStorageCollectionTransfer;
+use Generated\Shared\Transfer\ProductLabelStorageCriteriaTransfer;
+use Generated\Shared\Transfer\ProductLabelStorageTransfer;
+use Spryker\Client\ProductLabelStorage\Storage\Dictionary\DictionaryFactory;
+use Spryker\Client\ProductLabelStorage\Storage\ProductAbstractLabelReaderInterface;
+
+class ProductLabelStorageReader implements ProductLabelStorageReaderInterface
+{
+    /**
+     * @var \Spryker\Client\ProductLabelStorage\Storage\Dictionary\DictionaryFactory
+     */
+    protected $dictionaryFactory;
+
+    /**
+     * @var \Spryker\Client\ProductLabelStorage\Storage\ProductAbstractLabelReaderInterface
+     */
+    protected $productAbstractLabelReader;
+
+    /**
+     * @param \Spryker\Client\ProductLabelStorage\Storage\Dictionary\DictionaryFactory $dictionaryFactory
+     * @param \Spryker\Client\ProductLabelStorage\Storage\ProductAbstractLabelReaderInterface $productAbstractLabelReader
+     */
+    public function __construct(DictionaryFactory $dictionaryFactory, ProductAbstractLabelReaderInterface $productAbstractLabelReader)
+    {
+        $this->dictionaryFactory = $dictionaryFactory;
+        $this->productAbstractLabelReader = $productAbstractLabelReader;
+    }
+
+    /**
+     * @param \Generated\Shared\Transfer\ProductLabelStorageCriteriaTransfer $productLabelStorageCriteriaTransfer
+     *
+     * @return \Generated\Shared\Transfer\ProductLabelStorageTransfer|null
+     */
+    public function findProductLabel(ProductLabelStorageCriteriaTransfer $productLabelStorageCriteriaTransfer): ?ProductLabelStorageTransfer
+    {
+        $productLabelStorageCollectionTransfer = $this->getProductLabelCollection($productLabelStorageCriteriaTransfer);
+
+        if (!(array)$productLabelStorageCollectionTransfer->getProductLabels()) {
+            return null;
+        }
+
+        return $productLabelStorageCollectionTransfer->getProductLabels()[0];
+    }
+
+    /**
+     * @param \Generated\Shared\Transfer\ProductLabelStorageCriteriaTransfer $productLabelStorageCriteriaTransfer
+     *
+     * @return \Generated\Shared\Transfer\ProductLabelStorageCollectionTransfer
+     */
+    public function getProductLabelCollection(ProductLabelStorageCriteriaTransfer $productLabelStorageCriteriaTransfer): ProductLabelStorageCollectionTransfer
+    {
+        $productLabels = $this->dictionaryFactory->createDictionaryByIdProductLabel()->getDictionary(
+            $productLabelStorageCriteriaTransfer->getLocaleName(),
+            $productLabelStorageCriteriaTransfer->getStoreName()
+        );
+        $productLabelIds = $productLabelStorageCriteriaTransfer->getProductLabelIds();
+
+        if ($productLabelStorageCriteriaTransfer->getProductAbstractIds()) {
+            $productAbstractsProductLabelIds = $this->productAbstractLabelReader->getProductAbstractsProductLabelIds(
+                $productLabelStorageCriteriaTransfer->getProductAbstractIds()
+            );
+
+            $productLabelIds = $this->getFilteringProductLabelIds($productLabelIds, $productAbstractsProductLabelIds);
+        }
+
+        if ($productLabelIds) {
+            $productLabels = array_filter($productLabels, function ($productLabel) use ($productLabelIds) {
+                return in_array($productLabel->getIdProductLabel(), $productLabelIds, true);
+            });
+        }
+
+        $productLabelNames = $productLabelStorageCriteriaTransfer->getProductLabelNames();
+        if ($productLabelNames) {
+            $productLabels = array_filter($productLabels, function ($productLabel) use ($productLabelNames) {
+                return in_array($productLabel->getName(), $productLabelNames, true);
+            });
+        }
+
+        $productLabelStorageCollectionTransfer = new ProductLabelStorageCollectionTransfer();
+        foreach ($productLabels as $productLabel) {
+            $productLabelStorageCollectionTransfer->addProductLabel(
+                (new ProductLabelStorageTransfer())->fromArray($productLabel->toArray())
+            );
+        }
+
+        return $productLabelStorageCollectionTransfer;
+    }
+
+    /**
+     * @param int[] $productLabelIds
+     * @param int[] $productAbstractsProductLabelIds
+     *
+     * @return int[]
+     */
+    protected function getFilteringProductLabelIds(array $productLabelIds, array $productAbstractsProductLabelIds): array
+    {
+        if ($productLabelIds) {
+            return array_intersect($productLabelIds, $productAbstractsProductLabelIds);
+        }
+
+        return $productAbstractsProductLabelIds;
+    }
+}

--- a/src/Spryker/Client/ProductLabelStorage/Reader/ProductLabelStorageReaderInterface.php
+++ b/src/Spryker/Client/ProductLabelStorage/Reader/ProductLabelStorageReaderInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace Spryker\Client\ProductLabelStorage\Reader;
+
+use Generated\Shared\Transfer\ProductLabelStorageCollectionTransfer;
+use Generated\Shared\Transfer\ProductLabelStorageCriteriaTransfer;
+use Generated\Shared\Transfer\ProductLabelStorageTransfer;
+
+interface ProductLabelStorageReaderInterface
+{
+    /**
+     * @param \Generated\Shared\Transfer\ProductLabelStorageCriteriaTransfer $productLabelStorageCriteriaTransfer
+     *
+     * @return \Generated\Shared\Transfer\ProductLabelStorageTransfer|null
+     */
+    public function findProductLabel(ProductLabelStorageCriteriaTransfer $productLabelStorageCriteriaTransfer): ?ProductLabelStorageTransfer;
+
+    /**
+     * @param \Generated\Shared\Transfer\ProductLabelStorageCriteriaTransfer $productLabelStorageCriteriaTransfer
+     *
+     * @return \Generated\Shared\Transfer\ProductLabelStorageCollectionTransfer
+     */
+    public function getProductLabelCollection(ProductLabelStorageCriteriaTransfer $productLabelStorageCriteriaTransfer): ProductLabelStorageCollectionTransfer;
+}

--- a/src/Spryker/Client/ProductLabelStorage/Storage/ProductAbstractLabelReader.php
+++ b/src/Spryker/Client/ProductLabelStorage/Storage/ProductAbstractLabelReader.php
@@ -103,6 +103,27 @@ class ProductAbstractLabelReader implements ProductAbstractLabelReaderInterface
     }
 
     /**
+     * @param int[] $productAbstractIds
+     *
+     * @return int[]
+     */
+    public function getProductAbstractsProductLabelIds(array $productAbstractIds): array
+    {
+        $storageKeys = $this->generateProductLabelStorageKeys($productAbstractIds);
+        $storageDataItems = $this->getProductLabelStorageDataItemsByProductLabelStorageKeys($storageKeys);
+
+        $productLabelIds = [];
+
+        foreach ($storageDataItems as $storageDataItem) {
+            if ($storageDataItem[static::KEY_PRODUCT_LABEL_IDS]) {
+                $productLabelIds[] = $storageDataItem[static::KEY_PRODUCT_LABEL_IDS];
+            }
+        }
+
+        return array_merge(...$productLabelIds);
+    }
+
+    /**
      * @param int[][] $productLabelIdsByProductAbstractIds
      * @param string $localeName
      *

--- a/src/Spryker/Client/ProductLabelStorage/Storage/ProductAbstractLabelReaderInterface.php
+++ b/src/Spryker/Client/ProductLabelStorage/Storage/ProductAbstractLabelReaderInterface.php
@@ -24,4 +24,11 @@ interface ProductAbstractLabelReaderInterface
      * @return \Generated\Shared\Transfer\ProductLabelDictionaryItemTransfer[][]
      */
     public function getProductLabelsByProductAbstractIds(array $productAbstractIds, string $localeName): array;
+
+    /**
+     * @param int[] $productAbstractIds
+     *
+     * @return int[]
+     */
+    public function getProductAbstractsProductLabelIds(array $productAbstractIds): array;
 }

--- a/src/Spryker/Shared/ProductLabelStorage/Transfer/product_label_storage.transfer.xml
+++ b/src/Spryker/Shared/ProductLabelStorage/Transfer/product_label_storage.transfer.xml
@@ -44,4 +44,25 @@
         <property name="idProductLabel" type="int"/>
     </transfer>
 
+    <transfer name="ProductLabelStorageCriteria">
+        <property name="localeName" type="string"/>
+        <property name="storeName" type="string"/>
+        <property name="productAbstractIds" type="int[]"/>
+        <property name="productLabelIds" type="int[]"/>
+        <property name="productLabelNames" type="string[]"/>
+    </transfer>
+
+    <transfer name="ProductLabelStorage">
+        <property name="idProductLabel" type="int"/>
+        <property name="name" type="string"/>
+        <property name="key" type="string"/>
+        <property name="isExclusive" type="bool"/>
+        <property name="position" type="int"/>
+        <property name="frontEndReference" type="string"/>
+    </transfer>
+
+    <transfer name="ProductLabelStorageCollection">
+        <property name="productLabels" type="ProductLabelStorage[]" singular="productLabel"/>
+    </transfer>
+
 </transfers>


### PR DESCRIPTION
- Developer(s): @a-sabaa 

- Ticket: https://spryker.atlassian.net/browse/AA-36

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   ProductLabelStorage  | minor                 |                       |

-----------------------------------------

#### Module ProductLabelStorage

##### Change log

### Improvements
- Introduced `ProductLabelStorageClient::get` and `ProductLabelStorageClient::findOne` functions

